### PR TITLE
Add factory method with Proxy object

### DIFF
--- a/src/main/java/com/squareup/pagerduty/incidents/PagerDuty.java
+++ b/src/main/java/com/squareup/pagerduty/incidents/PagerDuty.java
@@ -17,6 +17,9 @@ package com.squareup.pagerduty.incidents;
 
 
 import java.io.IOException;
+import java.net.Proxy;
+
+import com.squareup.okhttp.OkHttpClient;
 import retrofit.GsonConverterFactory;
 import retrofit.Retrofit;
 
@@ -33,6 +36,21 @@ public abstract class PagerDuty {
         .baseUrl(HOST) //
         .addConverterFactory(GsonConverterFactory.create())
         .build();
+    return create(apiKey, retrofit);
+  }
+
+  public static PagerDuty create(String apiKey, Proxy proxy) {
+    OkHttpClient okHttpClient = new OkHttpClient();
+
+    checkNotNull(proxy, "proxy");   // Make sure the proxy argument is not null
+
+    okHttpClient.setProxy(proxy);
+
+    Retrofit retrofit = new Retrofit.Builder() //
+            .baseUrl(HOST) //
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build();
     return create(apiKey, retrofit);
   }
 

--- a/src/main/java/com/squareup/pagerduty/incidents/PagerDuty.java
+++ b/src/main/java/com/squareup/pagerduty/incidents/PagerDuty.java
@@ -47,10 +47,10 @@ public abstract class PagerDuty {
     okHttpClient.setProxy(proxy);
 
     Retrofit retrofit = new Retrofit.Builder() //
-            .baseUrl(HOST) //
-            .client(okHttpClient)
-            .addConverterFactory(GsonConverterFactory.create())
-            .build();
+        .baseUrl(HOST) //
+        .client(okHttpClient)
+        .addConverterFactory(GsonConverterFactory.create())
+        .build();
     return create(apiKey, retrofit);
   }
 


### PR DESCRIPTION
Some organizations can make use of a firewall and delegate outgoing HTTP requests to a proxy server. 

With the current artifact, proxying requests to pagerduty requires pulling in four separate artifacts, as well as the following code:

      OkHttpClient okHttpClient = new OkHttpClient();
      Proxy proxy = new Proxy(...);
      okHttpClient.setProxy(proxy);
      Retrofit retrofit = new Retrofit.Builder()
            .baseUrl(PagerDuty.HOST)
            .addConverterFactory(GsonConverterFactory.create())
            .client(okHttpClient)
            .build();
      PagerDuty duty = PagerDuty.create("", retrofit);

This is messy and prone to error, as well as a leaky abstraction. The referenced pull request simplifies the creation of such an object to:

     Proxy proxy = new Proxy(...);
     PagerDuty pagerDuty = PagerDuty.create("", proxy);

This is much simpler and leaves the creation of the actual PagerDuty object inside the pagerduty-artifact incident, which also allows for the dependencies to be reduced to solely that artifact.
