### PR TITLE
Add Contexts (Images & Links) to Pagerduty triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@ Trigger trigger = new Trigger.Builder("Sync responded with code: " + code)
 pagerDuty.notify(trigger);
 ```
 
+Trigger an incident with images:
+```java
+Trigger trigger = new Trigger.Builder("Sync responded with code: " + code)
+    .addImage(Image.withoutOptional("example.com/image.jpg"));
+    .addImage(Image.withOptional("example.com/image.jpg", "example.com/alt.jpg", "alternative text"));
+    .build();
+pagerDuty.notify(trigger);
+```
+
+Trigger an incident with links:
+```java
+Trigger trigger = new Trigger.Builder("Sync responded with code: " + code)
+    .addLink(Link.withoutText("example.com/somefile.txt"));
+    .addLink(Link.withText("example.com/somefile.txt", "Some text"));
+    .build();
+pagerDuty.notify(trigger);
+```
+
+
 Resolving an incident requires its key:
 ```java
 Resolution resolution = new Resolution.Builder("feed-sync-12").build();

--- a/src/main/java/com/squareup/pagerduty/incidents/Context.java
+++ b/src/main/java/com/squareup/pagerduty/incidents/Context.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.pagerduty.incidents;
+
+
+class Context {
+    final String type;
+    final String href;
+
+    Context(String type, String href) {
+        this.type = type;
+        this.href = href;
+    }
+}
+
+

--- a/src/main/java/com/squareup/pagerduty/incidents/Image.java
+++ b/src/main/java/com/squareup/pagerduty/incidents/Image.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.pagerduty.incidents;
+
+
+final class Image extends Context {
+    final String src;
+    final String alt;
+
+    private Image(String href, String src, String alt) {
+        super("image", href);
+        this.src = src;
+        this.alt = alt;
+    }
+
+    static Image withOptional(String src, String href, String alt) {
+        return new Image(href, src, alt);
+    }
+
+    static Image withoutOptional(String src) {
+        return new Image(null, src, null);
+    }
+
+}

--- a/src/main/java/com/squareup/pagerduty/incidents/Link.java
+++ b/src/main/java/com/squareup/pagerduty/incidents/Link.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.pagerduty.incidents;
+
+final class Link extends Context {
+    final String text;
+
+    private Link(String href, String text) {
+        super("link", href);
+        this.text = text;
+    }
+
+    static Link withText(String href, String text) {
+        return new Link(href, text);
+    }
+
+    static Link withoutText(String href) {
+        return new Link(href, null);
+    }
+}

--- a/src/main/java/com/squareup/pagerduty/incidents/Trigger.java
+++ b/src/main/java/com/squareup/pagerduty/incidents/Trigger.java
@@ -15,7 +15,9 @@
  */
 package com.squareup.pagerduty.incidents;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.squareup.pagerduty.incidents.Util.checkArgument;
@@ -25,10 +27,12 @@ import static com.squareup.pagerduty.incidents.Util.checkStringArgument;
 /** Report a new or ongoing problem. */
 public final class Trigger extends Event {
   private static final int MAX_DESCRIPTION_LENGTH = 1024;
+  private final List<Context> contexts;
 
   private Trigger(String incidentKey, String description, String client, String clientUrl,
-      Map<String, String> details) {
+      Map<String, String> details, List<Context> contexts) {
     super(null, incidentKey, TYPE_TRIGGER, description, client, clientUrl, details);
+    this.contexts = contexts;
   }
 
   /**
@@ -36,12 +40,14 @@ public final class Trigger extends Event {
    * <p>
    * Calling {@link #withIncidentKey} is required. All other data is optional.
    */
+
   public static final class Builder {
     private final String description;
     private String incidentKey;
     private String client;
     private String clientUrl;
     private Map<String, String> details = new LinkedHashMap<>();
+    private List<Context> contexts = new ArrayList<Context>();
 
     /**
      * Build data to trigger a new incident.
@@ -91,6 +97,18 @@ public final class Trigger extends Event {
       return this;
     }
 
+    /** A link to be attached to the pager duty notification.*/
+    public Builder addLink(Link link) {
+      contexts.add(link);
+      return this;
+    }
+
+    /** An image to be attached to the pager duty notification.*/
+    public Builder addImage(Image image) {
+      contexts.add(image);
+      return this;
+    }
+
     /** Arbitrary name-value pairs which will be included in incident the log. */
     public Builder addDetails(Map<String, String> details) {
       checkNotNull(details, "details");
@@ -99,7 +117,7 @@ public final class Trigger extends Event {
     }
 
     public Trigger build() {
-      return new Trigger(incidentKey, description, client, clientUrl, details);
+      return new Trigger(incidentKey, description, client, clientUrl, details, contexts);
     }
   }
 }

--- a/src/test/java/com/squareup/pagerduty/incidents/ImageTest.java
+++ b/src/test/java/com/squareup/pagerduty/incidents/ImageTest.java
@@ -1,0 +1,56 @@
+
+
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.pagerduty.incidents;
+
+        import com.google.gson.Gson;
+        import org.junit.Test;
+
+        import static org.assertj.core.api.Assertions.assertThat;
+
+public class ImageTest {
+
+    private final Gson gson = new Gson();
+
+    @Test
+    public void withoutOptionalSerialization() {
+        Image image = Image.withoutOptional ("example.com/image.jpg");
+        String actual = gson.toJson(image);
+
+        String expected = ""
+                + "{"
+                + "\"src\":\"example.com/image.jpg\","
+                + "\"type\":\"image\""
+                + "}";
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void withOptionalSerialization() {
+        Image image = Image.withOptional ("example.com/image.jpg", "example.com/alt.jpg", "alternative text");
+        String actual = gson.toJson(image);
+
+        String expected = ""
+                + "{"
+                + "\"src\":\"example.com/image.jpg\","
+                + "\"alt\":\"alternative text\","
+                + "\"type\":\"image\","
+                + "\"href\":\"example.com/alt.jpg\""
+                + "}";
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/squareup/pagerduty/incidents/LinkTest.java
+++ b/src/test/java/com/squareup/pagerduty/incidents/LinkTest.java
@@ -1,0 +1,55 @@
+
+
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.pagerduty.incidents;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LinkTest {
+
+    private final Gson gson = new Gson();
+
+    @Test
+    public void withoutTextSerialization() {
+        Link link = Link.withoutText("example.com/somefile.txt");
+        String actual = gson.toJson(link);
+
+        String expected = ""
+                + "{"
+                + "\"type\":\"link\","
+                + "\"href\":\"example.com/somefile.txt\""
+                + "}";
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void withTextSerialization() {
+        Link link = Link.withText("example.com/somefile.txt", "Some text");
+        String actual = gson.toJson(link);
+
+        String expected = ""
+                + "{"
+                + "\"text\":\"Some text\","
+                + "\"type\":\"link\","
+                + "\"href\":\"example.com/somefile.txt\""
+                + "}";
+        assertThat(actual).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
As per the pagerduty [docs](https://developer.pagerduty.com/documentation/integration/events/trigger) on trigger events, links and images can be associated with a trigger via the contexts property.

This PR adds this capability.

I haven't done much Java development so this is my best attempt!

Cheers,
Jon