### PR TITLE
updated Gson dependency to match the version given within retrofit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.6.1</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>retrofit-mock</artifactId>
       <version>2.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.3.1</version>
+      <version>2.6.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Within my issue https://github.com/square/pagerduty-incidents/issues/19, I've found a problem that Gson doesn't match to the version, retrofit uses. This leads to different exceptions.