### PR TITLE
Update retrofit, converter-gson and retrofit-mock to version 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,18 +51,18 @@
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>retrofit</artifactId>
-      <version>2.0.0</version>
+      <version>2.6.0</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>converter-gson</artifactId>
-      <version>2.0.0</version>
+      <version>2.6.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>retrofit-mock</artifactId>
-      <version>2.0.0</version>
+      <version>2.6.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Update retrofit, converter-gson and retrofit-mock to version 2.6.0.

These versions include fixes for CVE-2018-1000844 (https://github.com/square/retrofit/pull/2735) and CVE-2018-1000850 (https://github.com/square/retrofit/commit/b9a7f6ad72073ddd40254c0058710e87a073047d#diff-943ec7ed35e68201824904d1dc0ec982).