### PR TITLE
Improve EventTest#serialization

### DIFF
--- a/src/test/java/com/squareup/pagerduty/incidents/EventTest.java
+++ b/src/test/java/com/squareup/pagerduty/incidents/EventTest.java
@@ -16,6 +16,7 @@
 package com.squareup.pagerduty.incidents;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonParser;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,6 +43,7 @@ public final class EventTest {
         + "\"load avg\":\"0.75\""
         + "}"
         + "}";
-    assertThat(actual).isEqualTo(expected);
+    JsonParser parser = new JsonParser();
+    assertThat(parser.parse(actual)).isEqualTo(parser.parse(expected));
   }
 }


### PR DESCRIPTION
The test method `serialization()` tests the serialization of Json objects by comparing their string representations. Under most circumstances it won't be an issue, because it is usually expected that the fields have a fixed order.

However, in terms of specification, Gson implicitly relies on calling the Java method `getDeclaredFields()`, which its documentation said:

> The elements in the returned array are not sorted and are not in any particular order.

A plugin that can be useful to detect such potential problems [NonDex](https://github.com/TestingResearchIllinois/NonDex) can be used like this:

```
git clone https://github.com/square/pagerduty-incidents && cd pagerduty-incidents
mvn clean install -DskipTests
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.squareup.pagerduty.incidents.EventTest#serialization
```

Thus, it would be safer to compare objects directly, so that this non-determinism will never generate a false alarm. By serialize and then deserialize, if the test case passes, then one can still say that the serialization is valid, because they are deserialized to the same object.

Please do reply if there are anything that can be made better for this pull request :)
